### PR TITLE
Fix #57 : replace $PWD by $HOME in the `docker run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker build .
 ```
 docker run -d -v /tmp/.X11-unix/:/tmp/.X11-unix/ \
               -v /dev/shm:/dev/shm \
-              -v ${PWD}/.atom:/.atom \
+              -v ${HOME}/.atom:/.atom \
               -e DISPLAY=${DISPLAY} \
               jamesnetherton/docker-atom-editor
 ```


### PR DESCRIPTION
Replacing, in the README.md the variable in the volume path
`${PWD}/.atom` by `${HOME}/.atom` so the user can start atom
from anywhere.