### PR TITLE
add missing libxss library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
                     libnotify4 \
                     libxtst6 \
                     libnss3 \
+                    libxss1 \
                     gvfs-bin \
                     xdg-utils \
                     python && \


### PR DESCRIPTION
fixes this

```
% docker run -v /tmp/.X11-unix/:/tmp/.X11-unix/ \                                                   16-11-21 - 11:34:58
              -v /dev/shm:/dev/shm \
              -v ${HOME}/.atom:/home/atom/.atom \
              -e DISPLAY \
              jamesnetherton/docker-atom-editor
Unable to find image 'jamesnetherton/docker-atom-editor:latest' locally
latest: Pulling from jamesnetherton/docker-atom-editor



aed15891ba52: Pull complete
773ae8583d14: Pull complete
d1d48771f782: Pull complete
cd3d6cd6c0cf: Pull complete
8ff6f8a9120c: Pull complete
7e82e9269d00: Pull complete
Digest: sha256:336b0159c881079b8becbd7d26594a705e109104fd3aeac9bf6136c60f2c4797
Status: Downloaded newer image for jamesnetherton/docker-atom-editor:latest
/usr/share/atom/atom: error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory
```